### PR TITLE
Add ClickHouse backend

### DIFF
--- a/cryptofeed/backends/__init__.py
+++ b/cryptofeed/backends/__init__.py
@@ -1,0 +1,27 @@
+'''
+Copyright (C) 2017-2025 Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from cryptofeed.backends.arctic import TradeArctic, FundingArctic, TickerArctic, OpenInterestArctic, LiquidationsArctic, CandlesArctic, OrderInfoArctic, TransactionsArctic, BalancesArctic, FillsArctic
+from cryptofeed.backends.influxdb import TradeInflux, FundingInflux, BookInflux, TickerInflux, OpenInterestInflux, LiquidationsInflux, CandlesInflux, OrderInfoInflux, TransactionsInflux, BalancesInflux, FillsInflux
+from cryptofeed.backends.kafka import TradeKafka, FundingKafka, BookKafka, TickerKafka, OpenInterestKafka, LiquidationsKafka, CandlesKafka, OrderInfoKafka, TransactionsKafka, BalancesKafka, FillsKafka
+from cryptofeed.backends.mongo import TradeMongo, FundingMongo, BookMongo, TickerMongo, OpenInterestMongo, LiquidationsMongo, CandlesMongo, OrderInfoMongo, TransactionsMongo, BalancesMongo, FillsMongo
+from cryptofeed.backends.postgres import TradePostgres, FundingPostgres, TickerPostgres, OpenInterestPostgres, LiquidationsPostgres, BookPostgres, CandlesPostgres, OrderInfoPostgres, TransactionsPostgres, BalancesPostgres, FillsPostgres
+from cryptofeed.backends.quest import TradeQuest, FundingQuest, BookQuest, TickerQuest, OpenInterestQuest, LiquidationsQuest, CandlesQuest, OrderInfoQuest, TransactionsQuest, BalancesQuest, FillsQuest
+from cryptofeed.backends.rabbitmq import TradeRabbit, FundingRabbit, BookRabbit, TickerRabbit, OpenInterestRabbit, LiquidationsRabbit, CandlesRabbit, OrderInfoRabbit, TransactionsRabbit, BalancesRabbit, FillsRabbit
+from cryptofeed.backends.redis import TradeRedis, TradeStream, FundingRedis, FundingStream, BookRedis, BookStream, BookSnapshotRedisKey, TickerRedis, TickerStream, OpenInterestRedis, OpenInterestStream, LiquidationsRedis, LiquidationsStream, CandlesRedis, CandlesStream, OrderInfoRedis, OrderInfoStream, TransactionsRedis, TransactionsStream, BalancesRedis, BalancesStream, FillsRedis, FillsStream
+from cryptofeed.backends.zmq import TradeZMQ, FundingZMQ, BookZMQ, TickerZMQ, OpenInterestZMQ, LiquidationsZMQ, CandlesZMQ, BalancesZMQ, PositionsZMQ, OrderInfoZMQ, FillsZMQ, TransactionsZMQ
+from cryptofeed.backends.clickhouse import TradeClickHouse, FundingClickHouse, TickerClickHouse, OpenInterestClickHouse, LiquidationsClickHouse, CandlesClickHouse, OrderInfoClickHouse, TransactionsClickHouse, BalancesClickHouse, FillsClickHouse
+
+__all__ = ['TradeArctic', 'FundingArctic', 'TickerArctic', 'OpenInterestArctic', 'LiquidationsArctic', 'CandlesArctic', 'OrderInfoArctic', 'TransactionsArctic', 'BalancesArctic', 'FillsArctic',
+           'TradeInflux', 'FundingInflux', 'BookInflux', 'TickerInflux', 'OpenInterestInflux', 'LiquidationsInflux', 'CandlesInflux', 'OrderInfoInflux', 'TransactionsInflux', 'BalancesInflux', 'FillsInflux',
+           'TradeKafka', 'FundingKafka', 'BookKafka', 'TickerKafka', 'OpenInterestKafka', 'LiquidationsKafka', 'CandlesKafka', 'OrderInfoKafka', 'TransactionsKafka', 'BalancesKafka', 'FillsKafka',
+           'TradeMongo', 'FundingMongo', 'BookMongo', 'TickerMongo', 'OpenInterestMongo', 'LiquidationsMongo', 'CandlesMongo', 'OrderInfoMongo', 'TransactionsMongo', 'BalancesMongo', 'FillsMongo',
+           'TradePostgres', 'FundingPostgres', 'TickerPostgres', 'OpenInterestPostgres', 'LiquidationsPostgres', 'BookPostgres', 'CandlesPostgres', 'OrderInfoPostgres', 'TransactionsPostgres', 'BalancesPostgres', 'FillsPostgres',
+           'TradeQuest', 'FundingQuest', 'BookQuest', 'TickerQuest', 'OpenInterestQuest', 'LiquidationsQuest', 'CandlesQuest', 'OrderInfoQuest', 'TransactionsQuest', 'BalancesQuest', 'FillsQuest',
+           'TradeRabbit', 'FundingRabbit', 'BookRabbit', 'TickerRabbit', 'OpenInterestRabbit', 'LiquidationsRabbit', 'CandlesRabbit', 'OrderInfoRabbit', 'TransactionsRabbit', 'BalancesRabbit', 'FillsRabbit',
+           'TradeRedis', 'TradeStream', 'FundingRedis', 'FundingStream', 'BookRedis', 'BookStream', 'BookSnapshotRedisKey', 'TickerRedis', 'TickerStream', 'OpenInterestRedis', 'OpenInterestStream', 'LiquidationsRedis', 'LiquidationsStream', 'CandlesRedis', 'CandlesStream', 'OrderInfoRedis', 'OrderInfoStream', 'TransactionsRedis', 'TransactionsStream', 'BalancesRedis', 'BalancesStream', 'FillsRedis', 'FillsStream',
+           'TradeZMQ', 'FundingZMQ', 'BookZMQ', 'TickerZMQ', 'OpenInterestZMQ', 'LiquidationsZMQ', 'CandlesZMQ', 'BalancesZMQ', 'PositionsZMQ', 'OrderInfoZMQ', 'FillsZMQ', 'TransactionsZMQ',
+           'TradeClickHouse', 'FundingClickHouse', 'TickerClickHouse', 'OpenInterestClickHouse', 'LiquidationsClickHouse', 'CandlesClickHouse', 'OrderInfoClickHouse', 'TransactionsClickHouse', 'BalancesClickHouse', 'FillsClickHouse']

--- a/cryptofeed/backends/clickhouse.py
+++ b/cryptofeed/backends/clickhouse.py
@@ -1,0 +1,62 @@
+'''
+Copyright (C) 2017-2025 Bryant Moscon - bmoscon@gmail.com
+
+Please see the LICENSE file for the terms and conditions
+associated with this software.
+'''
+from clickhouse_connect import Client
+from cryptofeed.backends.backend import BackendCallback, BackendQueue
+from cryptofeed.defines import TRADES, FUNDING, TICKER, OPEN_INTEREST, LIQUIDATIONS, CANDLES, ORDER_INFO, TRANSACTIONS, BALANCES, FILLS
+
+
+class ClickHouseCallback(BackendQueue):
+    def __init__(self, database, host='localhost', port=9000, user='default', password='', table=None, **kwargs):
+        self.client = Client(host=host, port=port, user=user, password=password, database=database)
+        self.table = table if table else self.default_table
+        self.running = True
+
+    async def writer(self):
+        while self.running:
+            async with self.read_queue() as updates:
+                for update in updates:
+                    self.client.insert(self.table, [update])
+
+
+class TradeClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = TRADES
+
+
+class FundingClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = FUNDING
+
+
+class TickerClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = TICKER
+
+
+class OpenInterestClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = OPEN_INTEREST
+
+
+class LiquidationsClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = LIQUIDATIONS
+
+
+class CandlesClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = CANDLES
+
+
+class OrderInfoClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = ORDER_INFO
+
+
+class TransactionsClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = TRANSACTIONS
+
+
+class BalancesClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = BALANCES
+
+
+class FillsClickHouse(ClickHouseCallback, BackendCallback):
+    default_table = FILLS

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,23 @@
 * [Authenticated Channels](auth_channels.md)
 * [Performance Considerations](performance.md)
 * [REST endpoints](rest.md)
+* [ClickHouse Backend](clickhouse_backend.md)
+
+## ClickHouse Backend
+
+The ClickHouse backend allows you to store data in a ClickHouse database. It supports various data types such as trades, funding, ticker, open interest, liquidations, candles, order info, transactions, balances, and fills.
+
+### Example
+
+```python
+from cryptofeed import FeedHandler
+from cryptofeed.backends.clickhouse import TradeClickHouse, FundingClickHouse
+
+fh = FeedHandler()
+
+# Add ClickHouse backend
+fh.add_backend(TradeClickHouse(database='cryptofeed', table='trades'))
+fh.add_backend(FundingClickHouse(database='cryptofeed', table='funding'))
+
+fh.run()
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests>=2.18.4
 uvloop
 websockets>=14.1
 yapic.json>=1.6.3
+clickhouse-connect


### PR DESCRIPTION
Implement ClickHouse as a backend for storing data in the cryptofeed repository.

* **Add ClickHouse Backend Implementation**
  - Create `cryptofeed/backends/clickhouse.py` to define classes for different data types (e.g., TradeClickHouse, FundingClickHouse).
  - Use `clickhouse_connect` library for connecting to ClickHouse.
  - Implement methods for writing data to ClickHouse tables.

* **Update Backend Initialization**
  - Modify `cryptofeed/backends/__init__.py` to import ClickHouse backend classes.
  - Add ClickHouse backend classes to the `__all__` list.

* **Add Dependencies**
  - Update `requirements.txt` to include `clickhouse-connect` library.

* **Update Documentation**
  - Modify `docs/README.md` to include ClickHouse backend.
  - Add a brief description and example of using ClickHouse backend.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bmoscon/cryptofeed?shareId=XXXX-XXXX-XXXX-XXXX).

### Description of code - what bug does this fix / what feature does this add?

- [ ] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
